### PR TITLE
ci: バージョンアップ検知の仕組みを整備

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+
+updates:
+  # npm の依存を毎週チェックする。
+  # これまで dependabot.yml が無く、脆弱性が出たときしか PR が来なかったため、
+  # @nuxt/ui 2.21 → 4.8 のような大きなジャンプが発生していた。
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Tokyo
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: chore(deps)
+      prefix-development: chore(deps-dev)
+    groups:
+      # minor / patch はまとめて1本にしてレビュー負荷を下げる。
+      # major はこのグループから外れて個別 PR になるので、
+      # 「単独で慎重に検証すべきもの」が一目で分かる。
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  # ワークフローで使う action 自体も更新対象にする
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: chore(ci)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,87 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# 同じブランチで新しい push があったら古い実行は打ち切る
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      # npm install ではなく npm ci を使う。
+      # lockfile と package.json のズレを検知するため（issue #91 はこれが無くて半年埋もれた）。
+      - name: 依存をインストール
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: ビルド
+        run: npm run build
+
+      # ビルドが通っても実行時に壊れていることがある。
+      # Nuxt 4 移行時、アイコンの全滅とページの 500 はどちらもビルド成功のまま起きた。
+      # DB が要るページは Actions から Atlas に繋げないので、静的ページで検証する。
+      - name: スモークテスト
+        run: |
+          set -euo pipefail
+
+          node .output/server/index.mjs &
+          SERVER_PID=$!
+          trap 'kill $SERVER_PID 2>/dev/null || true' EXIT
+
+          echo "サーバーの起動を待機"
+          for i in $(seq 1 60); do
+            if curl -sf -o /dev/null http://localhost:3000/contact; then
+              echo "起動を確認"
+              break
+            fi
+            if [ "$i" -eq 60 ]; then
+              echo "::error::サーバーが 60 秒以内に起動しなかった"
+              exit 1
+            fi
+            sleep 1
+          done
+
+          echo "静的ページが 200 を返すか"
+          for path in / /contact /privacy /terms /license; do
+            code=$(curl -s -o /dev/null -w '%{http_code}' "http://localhost:3000$path")
+            echo "  $code $path"
+            if [ "$code" != "200" ]; then
+              echo "::error::$path が $code を返した"
+              exit 1
+            fi
+          done
+
+          echo "アイコンが解決できているか"
+          # @iconify-json/* が抜けると、ビルドは通るのにアイコンが一切出なくなる
+          curl -sf http://localhost:3000/contact -o page.html
+          if ! grep -q 'i-heroicons:' page.html; then
+            echo "::error::heroicons のクラスが SSR 出力に無い。@iconify-json/heroicons の導入を確認"
+            exit 1
+          fi
+          echo "  検出: $(grep -o 'i-heroicons:[a-z0-9-]*' page.html | sort -u | tr '\n' ' ')"
+
+          echo "404 が 404 を返すか"
+          code=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:3000/no-such-page)
+          if [ "$code" != "404" ]; then
+            echo "::error::存在しないパスが $code を返した"
+            exit 1
+          fi
+
+          echo "スモークテスト成功"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,7 @@
         "mongoose": "^8.24.1",
         "nodemailer": "^9.0.1",
         "nuxt": "^4.5.2",
-        "nuxt-csurf": "^1.6.5",
-        "vue": "latest",
-        "vue-router": "latest"
+        "nuxt-csurf": "^1.6.5"
       },
       "devDependencies": {
         "@iconify-json/heroicons": "^1.2.3",
@@ -11558,7 +11556,9 @@
       "version": "6.6.4",
       "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
       "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@vue/devtools-core": {
       "version": "8.2.1",
@@ -21647,6 +21647,8 @@
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.6.4.tgz",
       "integrity": "sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@vue/devtools-api": "^6.6.4"
       },

--- a/package.json
+++ b/package.json
@@ -19,9 +19,7 @@
     "mongoose": "^8.24.1",
     "nodemailer": "^9.0.1",
     "nuxt": "^4.5.2",
-    "nuxt-csurf": "^1.6.5",
-    "vue": "latest",
-    "vue-router": "latest"
+    "nuxt-csurf": "^1.6.5"
   },
   "devDependencies": {
     "@iconify-json/heroicons": "^1.2.3",


### PR DESCRIPTION
Nuxt 4 移行を振り返って、更新の検知体制に3つ穴があったので塞ぐ。

## 背景

@nuxt/ui が 2.21 → 4.8 という大ジャンプになったのは偶然ではなく、
**定期的なバージョン更新 PR が一度も出ていなかった**ことが原因だった。

```
dependabot_security_updates: enabled   ← セキュリティ更新のみ
.github/dependabot.yml                 ← 存在しない
```

`dependabot.yml` が無いと Dependabot は脆弱性が出たときしか PR を作らない。
そのため Nuxt 4 のリリースにも気づけず、CVE が出て初めて強制的に大きく上げさせられていた。

さらに CI が Vercel の `nuxt build` だけだったため、**ビルドが通れば緑**になっていた。
Nuxt 4 移行で踏んだ不具合は、いずれもビルド成功のまま発生している。

| 不具合 | `nuxt build` | 実際 |
|---|---|---|
| アイコンが全て非表示 | 成功 | 表示されない |
| `/nurseries` が 500 | 成功 | ページが落ちる |
| `npm ci` の lockfile 不整合（#91） | 成功 | 半年間気づかず |
| dev 起動時の unhandledRejection | 成功 | dev が壊れる |

## 変更

### 1. `.github/dependabot.yml`

npm を毎週チェックする。`groups` で minor / patch を1本にまとめ、
**major はグループから外れて個別 PR になる**ため、慎重に検証すべきものが一目で分かる。
github-actions も月次で更新対象にした。

### 2. `.github/workflows/ci.yml`

`npm ci` → `lint` → `build` → スモークテスト。

- **`npm ci` を使う** — lockfile と package.json のズレを検知する。issue #91 が半年埋もれた穴
- **ビルド後に実際にサーバーを起動する** — 静的5ページが 200 か、SSR 出力に heroicons の
  クラスがあるか、404 が 404 を返すかを確認する

DB が要るページ（`/nurseries`）は Actions から Atlas に繋げないため対象外。
dev 用 DB を用意すればここも広げられる。

### 3. `vue` / `vue-router` を直接依存から外す

`"latest"` 指定だったため意図しないメジャーがいつでも入りうる状態で、
実際 `vue-router` は 4.6.4 と 5.2.0 が同時にインストールされていた。

```
+-- @nuxt/ui@4.10.0
| `-- vue-router@4.6.4 deduped
+-- nuxt@4.5.2
| `-- vue-router@5.2.0
`-- vue-router@4.6.4             ← "latest" 指定なのに 4 系
```

どこからも直接 import しておらず（全て Nuxt の自動 import）、nuxt 自身が
`vue ^3.5.40` / `vue-router ^5.2.0` を dependencies に持つため外して問題ない。
これで **`vue` は 3.5.41 に一本化**された。

## 検証

- `npm ci` → `npm run lint` → `npm run build` が全て成功
- `npm ci --dry-run` が exit 0（lockfile 整合）
- スモークテストの判定条件をローカルの本番ビルドで実行して確認

  ```
  200 /  200 /contact  200 /privacy  200 /terms  200 /license
  検出: i-heroicons:envelope i-heroicons:home i-heroicons:pencil
  404 /no-such-page
  スモークテスト成功
  ```

- **アイコン判定をわざと失敗させると exit 1 になることも確認済み。**
  素通りするテストではない

## 補足

`vue-router` の 4.6.4 / 5.2.0 重複は @nuxt/ui と nuxt の peer 解決の都合で残る。
`npm dedupe` での一本化も試したが、`nostics` が 0.2.0 に巻き上げられて
**本番サーバーが起動しなくなる**ため採用しなかった
（`SyntaxError: 'nostics' does not provide an export named 'createConsoleReporter'`）。
アプリの動作には影響していないため現状維持とする。
